### PR TITLE
Do not loop infinitely if there is no argument passed to kiwix-serve.

### DIFF
--- a/src/server/kiwix-serve.cpp
+++ b/src/server/kiwix-serve.cpp
@@ -517,7 +517,7 @@ int main(int argc, char **argv) {
           break;
       }
     } else {
-      if (optind < argc) {
+      if (optind <= argc) {
 	if (libraryFlag)
 	{
 	  libraryPath = argv[optind++];


### PR DESCRIPTION
If there is no argument, optind==argc==1. We must not try to look into argv[1]
but we need to break the loop anyway.
